### PR TITLE
Remove shebang

### DIFF
--- a/protonvpn_gui/view/server_list_components/server_load.py
+++ b/protonvpn_gui/view/server_list_components/server_load.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import gi
 from math import pi
 gi.require_version('Gtk', '3.0')


### PR DESCRIPTION
This shebang is not required here and if left on the file it
causes openSUSE Build System to trigger a warning in the package build.