### PR TITLE
Add Keywords=vpn; to protonvpn.desktop

### DIFF
--- a/protonvpn.desktop
+++ b/protonvpn.desktop
@@ -7,3 +7,4 @@ Icon=protonvpn-logo
 StartupWMClass=Protonvpn
 Comment=ProtonVPN GUI client
 Categories=Network;
+Keywords=vpn;


### PR DESCRIPTION
I've added "Keywords=vpn;" to make it easier to launch the app from the GNOME overview since a person may search for "vpn" when looking to launch the ProtonVPN app. Without the keyword, GNOME will fail to find anything when searching for "vpn".