### PR TITLE
Pin markupsafe version dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author_email="contact@protonvpn.com",
     long_description=long_description,
     install_requires=[
-        "protonvpn-nm-lib~=3.4", "psutil"
+        "protonvpn-nm-lib~=3.4", "psutil","markupsafe==2.0.1"
     ],
     include_package_data=True,
     license="GPLv3",


### PR DESCRIPTION
markupsafe removed soft_unicode in newer versions which causes the GUI to fail.  Pin the version until a fix is implemented. See https://github.com/pallets/markupsafe/issues/304