### PR TITLE
Set the icon theme path for tray icons

### DIFF
--- a/protonvpn_gui/constants.py
+++ b/protonvpn_gui/constants.py
@@ -17,9 +17,9 @@ LOGGER_NAME = "protonvpn-gui"
 
 
 protonvpn_logo = "protonvpn-logo.png"
-VPN_TRAY_ON = "vpn-connected.svg"
-VPN_TRAY_OFF = "vpn-disconnected.svg"
-VPN_TRAY_ERROR = "vpn-no-network.svg"
+VPN_TRAY_ON = "vpn-connected"
+VPN_TRAY_OFF = "vpn-disconnected"
+VPN_TRAY_ERROR = "vpn-no-network"
 
 KILLSWITCH_ICON_SET = {
     DashboardKillSwitchIconEnum.OFF:

--- a/protonvpn_gui/view/indicator.py
+++ b/protonvpn_gui/view/indicator.py
@@ -98,9 +98,6 @@ class DummyIndicator(MetaIndicator):
 
 class ProtonVPNIndicator(MetaIndicator):
     _type = "indicator"
-    ON_PATH = os.path.join(ICON_DIR_PATH, VPN_TRAY_ON)
-    OFF_PATH = os.path.join(ICON_DIR_PATH, VPN_TRAY_OFF)
-    ERROR_PATH = os.path.join(ICON_DIR_PATH, VPN_TRAY_ERROR)
 
     def __init__(self, application):
         gi.require_version("AppIndicator3", "0.1")
@@ -114,8 +111,8 @@ class ProtonVPNIndicator(MetaIndicator):
             appindicator.IndicatorCategory.APPLICATION_STATUS)
         self.__indicator.set_status(appindicator.IndicatorStatus.ACTIVE)
         self.__indicator.set_menu(self.__menu)
-
-        self.__indicator.set_icon_full(self.OFF_PATH, "protonvpn")
+        self.__indicator.set_icon_theme_path(ICON_DIR_PATH)
+        self.__indicator.set_icon_full(VPN_TRAY_OFF, "protonvpn")
 
     @property
     def application(self):
@@ -204,12 +201,12 @@ class ProtonVPNIndicator(MetaIndicator):
             logger.exception(e)
 
     def set_connected_state(self):
-        self.__indicator.set_icon_full(self.ON_PATH, "protonvpn")
+        self.__indicator.set_icon_full(VPN_TRAY_ON, "protonvpn")
         self.__quick_connect_item.hide()
         self.__disconnect_item.show()
 
     def set_disconnected_state(self, hide_quick_connect=False):
-        self.__indicator.set_icon_full(self.OFF_PATH, "protonvpn")
+        self.__indicator.set_icon_full(VPN_TRAY_OFF, "protonvpn")
         self.__disconnect_item.hide()
         if hide_quick_connect:
             self.__quick_connect_item.hide()
@@ -218,7 +215,7 @@ class ProtonVPNIndicator(MetaIndicator):
         self.__quick_connect_item.show()
 
     def set_error_state(self):
-        self.__indicator.set_icon_full(self.ERROR_PATH, "protonvpn")
+        self.__indicator.set_icon_full(VPN_TRAY_ERROR, "protonvpn")
 
     def setup_reply_subject(self):
         self.__indicator_login_action = ReplaySubject(buffer_size=1)


### PR DESCRIPTION
This fixes a problem where the tray indicator is broken on Budgie Desktop 10.8, which now uses a system tray following the StatusNotifier spec.

According to the [StatusNotifier spec](https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/StatusNotifierItem/) for tray items, the icon name:
> An icon can either be identified by its Freedesktop-compliant icon name, carried by this property, or by the icon data itself, carried by the property IconPixmap.

It is not technically allowed to be a path to the icon; it must be an icon name. Setting the icon theme path property and dropping the file extension from the names allows the tray icons to appear as expected in Budgie again, without breaking other desktop implementations that may be more lenient with the spec.

This change has been tested with Budgie Desktop, MATE Desktop, and KDE Plasma.